### PR TITLE
feat(auth): agent-friendly Bearer token authentication (#3)

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Tom Sayles
+"""
+auth.py
+─────────────────────────────────────────────────────────────────────────────
+Agent-friendly Bearer token authentication for the branded-pdf-service.
+
+Design
+------
+Operators configure API keys via:
+
+1. ``PDF_API_KEYS`` environment variable — comma-separated list of keys.
+2. ``/run/secrets/api-keys.txt`` — one key per line (Docker secrets
+   compatible path; configurable via ``PDF_API_KEYS_FILE`` env var).
+
+When no keys are configured the service starts in **open mode**: all
+endpoints are accessible without authentication.  A warning is logged at
+startup.  This is intentional for development/local use and makes the
+default out-of-the-box experience frictionless.
+
+Protected vs open endpoints
+----------------------------
+Open (no auth required):
+  GET  /healthz
+  GET  /brands
+  GET  /brands/{slug}
+
+Protected (Bearer token required when keys are configured):
+  POST  /render
+  POST  /brands/{slug}
+  DELETE /brands/{slug}
+  GET  /brands/{slug}/preview
+
+Usage (FastAPI dependency)
+--------------------------
+::
+
+    from .auth import require_auth
+
+    @app.post("/render")
+    def render(
+        request: RenderRequest,
+        _: None = Depends(require_auth),
+    ) -> Response:
+        ...
+"""
+
+import logging
+import os
+import secrets
+from typing import FrozenSet, Optional
+
+from fastapi import HTTPException, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+logger = logging.getLogger(__name__)
+
+# ── Key loading ───────────────────────────────────────────────────────────────
+
+_KEYS_FILE_DEFAULT = "/run/secrets/api-keys.txt"
+
+
+def _load_keys() -> FrozenSet[str]:
+    """Load API keys from environment and/or key file.
+
+    Checks (in order):
+    1. ``PDF_API_KEYS`` env var — comma-separated.
+    2. ``PDF_API_KEYS_FILE`` env var (default ``/run/secrets/api-keys.txt``)
+       — one key per line; missing file is silently ignored.
+
+    Returns:
+        Frozenset of valid key strings.  Empty set = open mode.
+    """
+    keys = set()
+
+    env_keys = os.environ.get("PDF_API_KEYS", "").strip()
+    if env_keys:
+        for k in env_keys.split(","):
+            k = k.strip()
+            if k:
+                keys.add(k)
+
+    keys_file = os.environ.get(
+        "PDF_API_KEYS_FILE", _KEYS_FILE_DEFAULT
+    )
+    if os.path.isfile(keys_file):
+        try:
+            with open(keys_file, encoding="utf-8") as fh:
+                for line in fh:
+                    k = line.strip()
+                    if k and not k.startswith("#"):
+                        keys.add(k)
+        except OSError as exc:
+            logger.warning(
+                "Could not read API keys file '%s': %s", keys_file, exc
+            )
+
+    return frozenset(keys)
+
+
+def get_valid_keys() -> FrozenSet[str]:
+    """Return the current set of valid API keys.
+
+    Re-reads from environment and key file on every call so keys can be
+    rotated without restarting the service.
+
+    Returns:
+        Frozenset of valid key strings.
+    """
+    return _load_keys()
+
+
+def auth_is_enabled() -> bool:
+    """Return True if at least one API key is configured.
+
+    Returns:
+        True when the service is in protected mode; False for open mode.
+    """
+    return bool(get_valid_keys())
+
+
+# ── FastAPI dependency ────────────────────────────────────────────────────────
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def require_auth(
+    credentials: Optional[HTTPAuthorizationCredentials] = Security(
+        _bearer_scheme
+    ),
+) -> None:
+    """FastAPI dependency that enforces Bearer token authentication.
+
+    When no API keys are configured (open mode) this dependency is a
+    no-op.  When keys are configured, the ``Authorization: Bearer
+    <token>`` header must be present and the token must match one of the
+    configured keys.
+
+    Args:
+        credentials: Parsed ``Authorization`` header (injected by
+            FastAPI).
+
+    Raises:
+        HTTPException: 401 if the token is missing or invalid when auth
+            is enabled.
+    """
+    keys = get_valid_keys()
+
+    if not keys:
+        # Open mode — no keys configured.
+        return
+
+    if credentials is None or not credentials.credentials:
+        raise HTTPException(
+            status_code=401,
+            detail=(
+                "Authentication required. Provide an API key as "
+                "Authorization: Bearer <key>."
+            ),
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token = credentials.credentials
+    # Use secrets.compare_digest to guard against timing attacks.
+    valid = any(
+        secrets.compare_digest(token, key) for key in keys
+    )
+    if not valid:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid API key.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )

--- a/app/keygen.py
+++ b/app/keygen.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Tom Sayles
+"""
+keygen.py
+─────────────────────────────────────────────────────────────────────────────
+CLI helper to generate a cryptographically secure API key.
+
+Usage
+-----
+::
+
+    python -m app.keygen
+
+Generates a single URL-safe, base64-encoded 32-byte random token and
+prints it to stdout.  Suitable for use in ``PDF_API_KEYS`` or an
+``api-keys.txt`` secrets file.
+
+Example
+-------
+::
+
+    $ python -m app.keygen
+    gX3vL9mQpAeKFzWs8nRb2cYuJhDiOtTe1xN7BqVlMkIwCjSdUf0PrGaHoZyXvE
+
+The generated token is 43 characters long (32 bytes base64url without
+padding).  Generating multiple tokens gives one key per invocation; pipe
+to a file to accumulate keys::
+
+    python -m app.keygen >> secrets/api-keys.txt
+"""
+
+import secrets
+import sys
+
+
+def generate_key() -> str:
+    """Generate a cryptographically secure URL-safe API key.
+
+    Returns:
+        43-character URL-safe base64 string (32 bytes of entropy).
+    """
+    return secrets.token_urlsafe(32)
+
+
+def main() -> None:
+    """CLI entry point: print one new key to stdout."""
+    print(generate_key())
+
+
+if __name__ == "__main__":
+    main()

--- a/app/main.py
+++ b/app/main.py
@@ -22,11 +22,13 @@ import os
 import re
 import shutil
 import subprocess
+from contextlib import asynccontextmanager
 from typing import List, Optional
 
-from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi import Depends, FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse, Response
 
+from .auth import auth_is_enabled, require_auth
 from .models import (
     BrandMetaResponse,
     BrandUploadResponse,
@@ -48,6 +50,21 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+# ── Lifespan ──────────────────────────────────────────────────────────────────
+
+
+@asynccontextmanager
+async def _lifespan(application):
+    """FastAPI lifespan: log auth mode at startup."""
+    if auth_is_enabled():
+        logger.info("Auth enabled — Bearer token required for writes.")
+    else:
+        logger.warning(
+            "Auth DISABLED — no PDF_API_KEYS configured. "
+            "Set PDF_API_KEYS to enable authentication."
+        )
+    yield
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -99,6 +116,7 @@ app = FastAPI(
         "or pre-loaded from the ``/brands`` volume mount."
     ),
     version="0.2.0",
+    lifespan=_lifespan,
 )
 
 
@@ -255,6 +273,7 @@ async def upload_brand(
         default=None,
         description="Optional PNG logo file.",
     ),
+    _: None = Depends(require_auth),
 ) -> JSONResponse:
     """Create or replace a brand configuration.
 
@@ -352,7 +371,10 @@ async def upload_brand(
         409: {"description": "Cannot delete the last brand."},
     },
 )
-def delete_brand(slug: str) -> Response:
+def delete_brand(
+    slug: str,
+    _: None = Depends(require_auth),
+) -> Response:
     """Remove a brand configuration from the service.
 
     The last registered brand cannot be deleted (the service requires at
@@ -407,7 +429,10 @@ def delete_brand(slug: str) -> Response:
         500: {"description": "Rendering error."},
     },
 )
-def preview_brand(slug: str) -> Response:
+def preview_brand(
+    slug: str,
+    _: None = Depends(require_auth),
+) -> Response:
     """Render a standard preview document using the specified brand.
 
     The preview exercises the full rendering pipeline (headings, body
@@ -467,7 +492,10 @@ def preview_brand(slug: str) -> Response:
         500: {"description": "Internal rendering error."},
     },
 )
-def render(request: RenderRequest) -> Response:
+def render(
+    request: RenderRequest,
+    _: None = Depends(require_auth),
+) -> Response:
     """Render one or more Markdown sections to a single branded PDF.
 
     The ``markdown`` field accepts either a plain string or a list of

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Tom Sayles
+"""
+test_auth.py
+─────────────────────────────────────────────────────────────────────────────
+Unit tests for the Bearer token authentication module.
+
+Tests cover:
+- open mode (no keys configured)
+- protected mode (keys configured)
+- open endpoints remain unauthenticated
+- protected endpoints require valid Bearer token
+- keygen produces distinct, URL-safe tokens
+"""
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ── Auth module unit tests ────────────────────────────────────────────────────
+
+
+class TestKeyLoading:
+    """Tests for app.auth._load_keys()."""
+
+    def test_empty_when_no_keys_configured(self, monkeypatch):
+        """Returns empty set when no env var and no key file."""
+        monkeypatch.delenv("PDF_API_KEYS", raising=False)
+        monkeypatch.setenv("PDF_API_KEYS_FILE", "/nonexistent/path.txt")
+        from app.auth import _load_keys
+        assert _load_keys() == frozenset()
+
+    def test_loads_from_env_var(self, monkeypatch):
+        """Parses comma-separated keys from PDF_API_KEYS."""
+        monkeypatch.setenv("PDF_API_KEYS", "key1, key2, key3 ")
+        monkeypatch.setenv("PDF_API_KEYS_FILE", "/nonexistent/path.txt")
+        from app.auth import _load_keys
+        keys = _load_keys()
+        assert "key1" in keys
+        assert "key2" in keys
+        assert "key3" in keys
+
+    def test_loads_from_key_file(self, monkeypatch, tmp_path):
+        """Reads keys from file, one per line, ignores comments."""
+        key_file = tmp_path / "api-keys.txt"
+        key_file.write_text("# comment\nfilekey1\nfilekey2\n", encoding="utf-8")
+        monkeypatch.delenv("PDF_API_KEYS", raising=False)
+        monkeypatch.setenv("PDF_API_KEYS_FILE", str(key_file))
+        from app.auth import _load_keys
+        keys = _load_keys()
+        assert "filekey1" in keys
+        assert "filekey2" in keys
+        assert "# comment" not in keys
+
+    def test_merges_env_and_file(self, monkeypatch, tmp_path):
+        """Keys from env var and file are combined."""
+        key_file = tmp_path / "api-keys.txt"
+        key_file.write_text("filekey\n", encoding="utf-8")
+        monkeypatch.setenv("PDF_API_KEYS", "envkey")
+        monkeypatch.setenv("PDF_API_KEYS_FILE", str(key_file))
+        from app.auth import _load_keys
+        keys = _load_keys()
+        assert "envkey" in keys
+        assert "filekey" in keys
+
+
+# ── Endpoint-level auth tests ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def isolated_brands_dir(tmp_path, monkeypatch):
+    """Set up a temp brands dir with acme-test brand."""
+    import json
+    brands_root = tmp_path / "brands"
+    brands_root.mkdir()
+    acme_dir = brands_root / "acme-test"
+    acme_dir.mkdir()
+    meta = {"org_name": "Test", "footer_text": "Test", "default_font": "Liberation Sans", "heading_font": "Liberation Serif"}
+    (acme_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    (acme_dir / "brand.typ").write_text("#set page()\n", encoding="utf-8")
+
+    monkeypatch.setenv("BRANDS_DIR", str(brands_root))
+    import app.renderer as renderer
+    import app.main as main_module
+    renderer.BRANDS_DIR = str(brands_root)
+    main_module.BRANDS_DIR = str(brands_root)
+    yield str(brands_root)
+
+
+@pytest.fixture
+def open_client(isolated_brands_dir, monkeypatch):
+    """TestClient with auth DISABLED (no keys configured)."""
+    monkeypatch.delenv("PDF_API_KEYS", raising=False)
+    monkeypatch.setenv("PDF_API_KEYS_FILE", "/nonexistent/path.txt")
+    from app.main import app
+    return TestClient(app)
+
+
+@pytest.fixture
+def authed_client(isolated_brands_dir, monkeypatch):
+    """TestClient with auth ENABLED (test-key configured)."""
+    monkeypatch.setenv("PDF_API_KEYS", "test-secret-key-abc123")
+    monkeypatch.setenv("PDF_API_KEYS_FILE", "/nonexistent/path.txt")
+    from app.main import app
+    return TestClient(app)
+
+
+class TestOpenMode:
+    """Auth is disabled — all endpoints accessible without token."""
+
+    def test_healthz_open(self, open_client):
+        """GET /healthz succeeds in open mode."""
+        resp = open_client.get("/healthz")
+        assert resp.status_code == 200
+
+    def test_brands_list_open(self, open_client):
+        """GET /brands succeeds in open mode."""
+        resp = open_client.get("/brands")
+        assert resp.status_code == 200
+
+    def test_render_open(self, open_client):
+        """POST /render succeeds without auth in open mode."""
+        with patch("app.main.render_document", return_value=b"%PDF-fake"):
+            resp = open_client.post(
+                "/render",
+                json={"brand": "acme-test", "markdown": "# Test"},
+            )
+        assert resp.status_code == 200
+
+    def test_brand_delete_open(self, open_client, isolated_brands_dir):
+        """DELETE /brands/{slug} allowed in open mode if 2nd brand exists."""
+        import json
+        extra = os.path.join(isolated_brands_dir, "extra")
+        os.makedirs(extra)
+        with open(os.path.join(extra, "meta.json"), "w") as f:
+            json.dump({"org_name": "E"}, f)
+        with open(os.path.join(extra, "brand.typ"), "w") as f:
+            f.write("#set page()\n")
+        resp = open_client.delete("/brands/extra")
+        assert resp.status_code == 204
+
+
+class TestProtectedMode:
+    """Auth is enabled — protected endpoints require Bearer token."""
+
+    def test_healthz_still_open(self, authed_client):
+        """GET /healthz remains unauthenticated even when auth is on."""
+        resp = authed_client.get("/healthz")
+        assert resp.status_code == 200
+
+    def test_brands_list_still_open(self, authed_client):
+        """GET /brands remains unauthenticated when auth is on."""
+        resp = authed_client.get("/brands")
+        assert resp.status_code == 200
+
+    def test_get_brand_meta_still_open(self, authed_client):
+        """GET /brands/{slug} (read) remains unauthenticated."""
+        resp = authed_client.get("/brands/acme-test")
+        assert resp.status_code == 200
+
+    def test_render_requires_token(self, authed_client):
+        """POST /render returns 401 without token."""
+        with patch("app.main.render_document", return_value=b"%PDF-fake"):
+            resp = authed_client.post(
+                "/render",
+                json={"brand": "acme-test", "markdown": "# Test"},
+            )
+        assert resp.status_code == 401
+
+    def test_render_accepts_valid_token(self, authed_client):
+        """POST /render succeeds with valid Bearer token."""
+        with patch("app.main.render_document", return_value=b"%PDF-fake"):
+            resp = authed_client.post(
+                "/render",
+                json={"brand": "acme-test", "markdown": "# Test"},
+                headers={"Authorization": "Bearer test-secret-key-abc123"},
+            )
+        assert resp.status_code == 200
+
+    def test_render_rejects_wrong_token(self, authed_client):
+        """POST /render returns 401 with an invalid token."""
+        with patch("app.main.render_document", return_value=b"%PDF-fake"):
+            resp = authed_client.post(
+                "/render",
+                json={"brand": "acme-test", "markdown": "# Test"},
+                headers={"Authorization": "Bearer wrong-key"},
+            )
+        assert resp.status_code == 401
+
+    def test_preview_requires_token(self, authed_client):
+        """GET /brands/{slug}/preview returns 401 without token."""
+        with patch("app.main.render_document", return_value=b"%PDF-fake"):
+            resp = authed_client.get("/brands/acme-test/preview")
+        assert resp.status_code == 401
+
+    def test_upload_requires_token(self, authed_client):
+        """POST /brands/{slug} returns 401 without token."""
+        import json as json_module
+        data = {
+            "meta_json": json_module.dumps({"org_name": "X"}),
+            "brand_typ": "#set page()\n",
+        }
+        with patch("app.main.validate_brand_typ"):
+            resp = authed_client.post("/brands/new-brand", data=data)
+        assert resp.status_code == 401
+
+    def test_delete_requires_token(self, authed_client):
+        """DELETE /brands/{slug} returns 401 without token."""
+        resp = authed_client.delete("/brands/acme-test")
+        assert resp.status_code == 401
+
+
+# ── Keygen tests ──────────────────────────────────────────────────────────────
+
+
+class TestKeygen:
+    """Tests for app.keygen."""
+
+    def test_generates_non_empty_key(self):
+        """generate_key() returns a non-empty string."""
+        from app.keygen import generate_key
+        key = generate_key()
+        assert isinstance(key, str)
+        assert len(key) > 0
+
+    def test_generates_url_safe_key(self):
+        """generate_key() returns only URL-safe characters."""
+        from app.keygen import generate_key
+        import re
+        for _ in range(10):
+            key = generate_key()
+            assert re.match(r'^[A-Za-z0-9_\-]+$', key), (
+                f"Key contains non-URL-safe chars: {key}"
+            )
+
+    def test_generates_distinct_keys(self):
+        """generate_key() produces unique keys."""
+        from app.keygen import generate_key
+        keys = {generate_key() for _ in range(20)}
+        assert len(keys) == 20


### PR DESCRIPTION
Closes #3

## What this PR adds

Lightweight Bearer token auth for protected endpoints.

### Protected (require Bearer token when keys configured)
- \POST /render\
- \POST /brands/{slug}\
- \DELETE /brands/{slug}\
- \GET /brands/{slug}/preview\

### Always open
- \GET /healthz\
- \GET /brands\
- \GET /brands/{slug}\

### Key configuration
- \PDF_API_KEYS\ env var — comma-separated
- \PDF_API_KEYS_FILE\ — one key per line (default: \/run/secrets/api-keys.txt\)
- No keys configured = open mode (logs warning)

### Keygen
\\\
python -m app.keygen   # prints one 32-byte URL-safe token
\\\

## Merge strategy
Squash merge per CONTRIBUTING.md.

## Checklist
- [x] 43 unit tests pass (20 new auth tests)
- [ ] Smoke test on docker-host-2 (open mode + keyed mode) ✅