### PR TITLE
fix(ci): add load:true to buildx build step, run all tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install test dependencies
-        run: pip install pytest requests fastapi pydantic reportlab pypdf
+        run: pip install pytest requests fastapi pydantic reportlab pypdf python-multipart httpx mcp
 
       - name: Run unit tests
-        run: pytest tests/test_brand_loader.py -v
+        run: pytest tests/ -v
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,6 +36,7 @@ jobs:
           context: .
           platforms: linux/amd64
           push: false
+          load: true
           tags: branded-pdf-service:ci
 
       - name: Smoke-test healthz
@@ -44,6 +45,13 @@ jobs:
             -p 8100:8000 \
             -v ${{ github.workspace }}/brands/acme-corp:/brands/acme-corp:ro \
             branded-pdf-service:ci
-          sleep 15
+          for i in $(seq 1 12); do
+            sleep 5
+            if curl -sf http://localhost:8100/healthz; then
+              echo "Service is up"
+              break
+            fi
+            echo "Waiting... attempt $i/12"
+          done
           curl -f http://localhost:8100/healthz
           docker stop pdf-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: pip install pytest requests fastapi pydantic reportlab pypdf python-multipart httpx mcp
 
       - name: Run unit tests
-        run: pytest tests/ -v
+        run: pytest tests/ -v -m "not integration"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Planned
-- Phase 5a: Brand Management API (runtime CRUD for brand configs)
-- Phase 5b: KISS Authentication (Bearer token, agent-friendly)
-- Phase 5c: MCP Server interface (stdio transport, agent tool manifest)
+---
+
+## [0.2.1] -- 2026-03-23
+
+### Fixed
+- CI: `docker/build-push-action@v5` with `push: false` does not load the
+  built image into the local Docker daemon without `load: true`; the
+  `Smoke-test healthz` step was failing with "pull access denied" (#8)
+- CI: `pytest tests/ -v` collected `smoke_test.py` which makes live HTTP
+  requests — added `pytestmark = pytest.mark.integration` and run unit
+  tests with `-m "not integration"` to exclude live-service tests (#8)
+
+### Added
+- `pytest.ini` registering the `integration` marker
+- CI: expanded test dependencies (`python-multipart`, `httpx`, `mcp`)
+- CI: replaced fixed `sleep 15` healthz wait with a 60-second polling loop
+
+---
+
+## [0.2.0] -- 2026-03-23
+
+### Added
+- `GET /brands/{slug}` -- brand metadata endpoint (open, no auth required)
+- `POST /brands/{slug}` -- upload/replace a brand at runtime (multipart;
+  Typst template validated before save) (#2)
+- `DELETE /brands/{slug}` -- remove a brand; last-brand guard returns 409 (#2)
+- `GET /brands/{slug}/preview` -- render a one-page brand preview PDF (#2)
+- `app/auth.py` -- Bearer token authentication via `PDF_API_KEYS` env var
+  (comma-separated) or `PDF_API_KEYS_FILE`; open mode when unset (#4)
+- `app/keygen.py` -- `python -m app.keygen` generates a 32-byte URL-safe
+  token (#4)
+- `app/mcp_server.py` -- FastMCP stdio server exposing 5 tools:
+  `render_pdf`, `list_brands`, `get_brand_meta`, `upload_brand`,
+  `preview_brand` (#6)
+- `tests/test_brand_api.py` -- 17 unit tests for brand management endpoints
+- `tests/test_auth.py` -- 20 unit tests for auth (open and keyed mode)
+- `tests/test_mcp_server.py` -- 13 unit tests for MCP tools
+
+### Changed
+- `app/main.py`: FastAPI lifespan context manager replaces deprecated
+  `on_event`; version bumped to 0.2.0
+- Protected endpoints (`POST /render`, `POST/DELETE /brands/{slug}`,
+  `GET /brands/{slug}/preview`) require `Authorization: Bearer <token>`
+  when auth is enabled
+- `requirements.txt`: added `python-multipart>=0.0.9`, `mcp[cli]>=1.0.0`
 
 ---
 
@@ -41,5 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   during Phase 6 homelab deployment. Docker is not available in the Windows
   development environment where this repo was assembled.
 
-[Unreleased]: https://github.com/tsayles/branded-pdf-service/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/tsayles/branded-pdf-service/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/tsayles/branded-pdf-service/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/tsayles/branded-pdf-service/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/tsayles/branded-pdf-service/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -278,7 +278,8 @@ PDF bytes returned in HTTP response
 |---------|--------|---------|
 | v0.1.0 | ✅ Released | Core rendering service (`POST /render`, brand templates, watermarks) |
 | v0.2.0 | ✅ Released | Brand Management API, KISS Authentication, MCP Server (stdio) |
-| v0.3.0 | 🗺️ Planned | Docker Hub publish; multi-arch image; CI image push on tag |
+| v0.2.1 | ✅ Released | CI fixes: buildx `load: true`, integration test marker, polling healthz |
+| v0.3.0 | 🗺️ Planned | Docker Hub publish; multi-arch CI image push on tag |
 
 ---
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: marks tests as integration tests requiring a live service
+                 (deselect with '-m "not integration"')

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -18,6 +18,8 @@ import os
 import pytest
 import requests
 
+pytestmark = pytest.mark.integration
+
 BASE_URL = os.environ.get("PDF_SERVICE_URL", "http://localhost:8100")
 
 SAMPLE_MARKDOWN = """


### PR DESCRIPTION
## Summary

Fixes the CI pipeline which was failing with two separate errors after
the initial `pytest tests/ -v` expansion in the first commit.

Closes #8

---

## What was broken and why

### Failure 1 — Docker image not found at `docker run`
`docker/build-push-action@v5` with `push: false` sends the built image
to the BuildKit cache only. Without `load: true`, the image is **not**
loaded into the local Docker daemon, so the subsequent `docker run`
fails immediately:

```
docker: Error response from daemon: pull access denied for branded-pdf-service,
repository does not exist or may require 'docker login'
```

### Failure 2 — Integration smoke tests run during unit test job
Expanding the test command from `pytest tests/test_brand_loader.py` to
`pytest tests/ -v` caused pytest to collect `tests/smoke_test.py`.
That file makes live HTTP requests to `http://localhost:8100` — but no
service is running during the unit test job, so every test fails with
`ConnectionRefused`.

---

## Changes

### Commit 1 — `f96c0f3`
- `ci.yml`: add `load: true` to the buildx build step so the image is
  available to `docker run`
- `ci.yml`: expand unit test dependencies (`python-multipart httpx mcp`)
  so all test modules import cleanly
- `ci.yml`: replace fixed `sleep 15` with a 60-second polling loop for
  the healthz smoke check (more reliable on slow runners)

### Commit 2 — `ff94558`
- `pytest.ini`: register `integration` marker to suppress pytest warnings
- `tests/smoke_test.py`: add `pytestmark = pytest.mark.integration`
- `ci.yml`: run unit tests as `pytest tests/ -v -m "not integration"` so
  live-service tests are never collected in the unit test job

---

## Running integration tests manually

```bash
# Against local docker-host-2
PDF_SERVICE_URL=http://192.168.11.105:8100 pytest tests/smoke_test.py -v

# Against a local container
docker run -d -p 8100:8000 -v ./brands/acme-corp:/brands/acme-corp branded-pdf-service:latest
pytest tests/smoke_test.py -v
```